### PR TITLE
Factor out constants, remove "hpc" host

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,6 @@ The script is meant to be used via the OpenSSH's [`ProxyCommand`](https://man.op
 Currently, the script requires manual configuration of SSH, typically via `~/.ssh/config` where `~` indicate the user's home folder.
 
 ```
-Host hpc
-    HostName fqdn.to.login.node
-
 Host hpcx
     ProxyCommand python /path/to/tunnel.py proxy
 ```
@@ -100,7 +97,7 @@ tunnel.start_job()
 # Return "hostname:port" as a string
 tunnel.get_compute_node_and_port()
 
-# Forward stdin and stdout to the compute node by running `ssh -W hostname:port hpc`
+# Forward stdin and stdout to the compute node by running `ssh -W hostname:port hpc_login_node`
 tunnel.do_proxy() # Should report the SSH version. Press Ctrl-D to terminate.
 ```
 

--- a/example/ssh_config
+++ b/example/ssh_config
@@ -1,7 +1,4 @@
 # Typically part of ~/.ssh/config
 
-Host hpc
-    Hostname login1.int.janelia.org
-
 Host hpcx
     ProxyCommand python /Users/kittisopikulm/tunnel/tunnel.py proxy

--- a/tunnel.py
+++ b/tunnel.py
@@ -9,11 +9,13 @@ import time
 # https://gist.github.com/haakon-e/e444972b99a5cd885ef6b29c86cb388e
 
 # Configuration
-LOGIN_NODE = "login1.int.janelia.org"
-JOB_ID_ENV_VAR = "LSB_JOBID"
-JOB_NAME = "tunnel"
-PROJECT_NAME = "scicompsoft"
 NUM_SLOTS = "1"
+JOB_TIME="8:00"
+JOB_QUEUE="local"
+PROJECT_NAME = "scicompsoft"
+LOGIN_NODE = "login1.int.janelia.org"
+JOB_NAME = "tunnel"
+JOB_ID_ENV_VAR = "LSB_JOBID"
 
 def get_available_port():
     """
@@ -96,7 +98,13 @@ def queue_job():
         print(f"Job with name \"{JOB_NAME}\" is already running")
     else:
         print("Queuing bsub job for tunnel")
-        command = ["bsub", "-n", NUM_SLOTS, "-P", PROJECT_NAME, "-J", JOB_NAME, "python", __file__]
+        command = ["bsub",
+                   "-n", NUM_SLOTS,
+                   "-P", PROJECT_NAME,
+                   "-J", JOB_NAME,
+                   "-q", JOB_QUEUE,
+                   "-W", JOB_TIME,
+                   "python", __file__]
         subprocess.run(command)
 
 def do_proxy():

--- a/tunnel.py
+++ b/tunnel.py
@@ -13,6 +13,7 @@ LOGIN_NODE = "login1.int.janelia.org"
 JOB_ID_ENV_VAR = "LSB_JOBID"
 JOB_NAME = "tunnel"
 PROJECT_NAME = "scicompsoft"
+NUM_SLOTS = "1"
 
 def get_available_port():
     """
@@ -95,7 +96,7 @@ def queue_job():
         print(f"Job with name \"{JOB_NAME}\" is already running")
     else:
         print("Queuing bsub job for tunnel")
-        command = ["bsub", "-n", "1", "-P", PROJECT_NAME, "-J", JOB_NAME, "python", __file__]
+        command = ["bsub", "-n", NUM_SLOTS, "-P", PROJECT_NAME, "-J", JOB_NAME, "python", __file__]
         subprocess.run(command)
 
 def do_proxy():


### PR DESCRIPTION
Move hard coded strings to be constants near the top of the script

Remove mention of a "hpc" host that needs to be configured in the script and ~/.ssh/config
